### PR TITLE
Performance improvements.

### DIFF
--- a/ConsoleApp1/ConsoleApp1.csproj
+++ b/ConsoleApp1/ConsoleApp1.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HtmlKit\HtmlKit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="UGGRoyale.mjml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/ConsoleApp1/Program.cs
+++ b/ConsoleApp1/Program.cs
@@ -1,0 +1,91 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+using HtmlKit;
+
+namespace ConsoleApp1
+{
+	internal class Program
+	{
+		static void Main (string[] args)
+		{
+			var input = File.ReadAllText ("UGGRoyale.mjml");
+
+			var v1 = TestV1(input);
+			var v2 = TestV1 (input);
+
+			var equals = v1.Equals (v2);
+			Console.WriteLine (equals);
+
+			ReadV1 (input);
+
+			Console.WriteLine ("V2");
+			ReadV2 (input);
+		}
+
+		private static string TestV1 (string input)
+		{
+			var sb = new StringBuilder ();
+
+			var reader = new HtmlTokenizer (new StringReader (input));
+
+			while (reader.ReadNextToken (out var token)) {
+				sb.Append (token.ToString ());
+			}
+
+			return sb.ToString ();
+
+		}
+
+		private static string TestV2 (string input)
+		{
+			var sb = new StringBuilder ();
+
+			using var reader = new HtmlTokenizer2 (new StringReader (input));
+
+			while (reader.ReadNextToken (out var token)) {
+				sb.Append (token.ToString ());
+			}
+
+			return sb.ToString ();
+		}
+
+		private static void ReadV2 (string input)
+		{
+			var watch = Stopwatch.StartNew ();
+
+			for (var i = 0; i < 1000; i++) {
+
+				var result = new List<object> ();
+				using var reader = new HtmlTokenizer2 (new StringReader (input));
+
+				while (reader.ReadNextToken (out var token)) {
+					result.Add (token);
+				}
+
+			}
+
+			Console.WriteLine (watch.Elapsed);
+			watch.Stop ();
+		}
+
+		private static void ReadV1 (string input)
+		{
+			var watch = Stopwatch.StartNew ();
+
+			for (var i = 0; i < 1000; i++) {
+
+				var result = new List<object> ();
+				var reader = new HtmlTokenizer2 (new StringReader (input));
+
+				while (reader.ReadNextToken (out var token)) {
+					result.Add (token);
+				}
+
+			}
+
+			Console.WriteLine (watch.Elapsed);
+			watch.Stop ();
+		}
+	}
+}

--- a/ConsoleApp1/UGGRoyale.mjml
+++ b/ConsoleApp1/UGGRoyale.mjml
@@ -1,0 +1,208 @@
+<mjml>
+  <mj-head>
+    <mj-title>UGG Royale</mj-title>
+    <mj-attributes>
+      <mj-image alt="" padding="0px"></mj-image>
+      <mj-section padding="0px"></mj-section>
+      <mj-class name="open-sans-button" font-family="Open Sans, Arial, sans-serif" background-color="#111111" color="#ffffff" height="30px" text-transform="uppercase" font-size="16px" text-decoration="none"></mj-class>
+      <mj-class name="footer-text" font-family="Open Sans, Arial, sans-serif" color="#111111" font-size="10px" line-height="14px"></mj-class>
+      <mj-class name="body-text" font-family="Open Sans, Arial, sans-serif" color="#111111" font-size="16px" line-height="26px" align="center"></mj-class>
+      <mj-class name="headline-text" font-family="Big Caslon, Garamond, Times, serif" color="#111111" font-size="40px" line-height="36px" align="center" text-transform="uppercase"></mj-class>
+    </mj-attributes>
+    <mj-font name="Open Sans" href="http://fonts.googleapis.com/css?family=Open+Sans"></mj-font>
+    <mj-style inline="inline">.link-nostyle { color: inherit; text-decoration: none }; /* Apple specific Links */ .apple-link-black a { color:#111111 !important; text-decoration:none; } .apple-link-gray a { color:#999999 !important; text-decoration:none; } .apple-link-white a
+      { color:#ffffff !important; text-decoration:none; } .apple-link-tan a { color: #aa6034 !important; text-decoration: none; } .apple-link-light-grey a { color: #c7c8ca; text-decoration: none; } .preheader {display:none !important; visibility:hidden;
+      mso-hide:all; max-height:0px; max-width:0px; opacity:0; overflow:hidden; width:100%;} img[class="img-max"] { max-width: 100% !important; width: 100% !important; height: auto !important; }
+    </mj-style>
+    <mj-style>@media all and (max-width: 600px) { img[title*="img30"] { width:30% !important; } }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#ffffff">
+    <mj-section padding="0px">
+      <mj-column>
+        <mj-text font-size="1px" align="left" color="#ffffff" line-height="1px" font-family="'Open Sans', 'Raleway', Arial, Verdana, sans-serif" padding="0px"><span class="preheader"> No longer on backorder, the Royale is now here and waiting for you.
+          </span></mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section background-color="#f9f9f9">
+      <mj-column>
+        <mj-text mj-class="body-text" font-size="14px" line-height="26px" letter-spacing="2px" text-transform="uppercase">Last Chance: Free two-day shipping on any order $100+ ends today</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-wrapper background-color="#f9f9f9" padding="0px">
+      <mj-section>
+        <mj-column>
+          <mj-image alt="Model in UGG in a baby blue royale" href="http://www.ugg.com/" width="600px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/main.jpg"></mj-image>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="30px 0 20px">
+        <mj-column>
+          <mj-text mj-class="headline-text">the<br /> wait
+            <br /> is over
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section>
+        <mj-column width="480px">
+          <mj-text mj-class="body-text">Due to popular demand, our best-selling sandal is back. Get yours before they sell out again.</mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-raw>&#60;!--[if !mso]&#62;&#60;\!--&#62;</mj-raw>
+      <mj-section>
+        <mj-column width="550px">
+          <mj-carousel tb-border-radius="0px" tb-hover-border-color="red" tb-width="50px" tb-border="0px" left-icon="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/arrow-left.png" right-icon="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/arrow-right.png" icon-width="16px">
+            <mj-carousel-image href="http://www.ugg.com/" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/BPNK.gif" alt="Side view of the Royal in Baby Pink" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product1.jpg"></mj-carousel-image>
+            <mj-carousel-image href="http://www.ugg.com/" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/NOPK.gif" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product2.jpg"></mj-carousel-image>
+            <mj-carousel-image href="http://www.ugg.com/" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/BBLU.gif" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product3.jpg"></mj-carousel-image>
+            <mj-carousel-image href="http://www.ugg.com/" alt="Side view of the Royal in Black" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/BLK.gif" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product4.jpg"></mj-carousel-image>
+            <mj-carousel-image href="http://www.ugg.com/" alt="Side view of the Royal in Seal" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/SEL.gif" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product5.jpg"></mj-carousel-image>
+            <mj-carousel-image href="http://www.ugg.com/" alt="Side view of the Royal in White" thumbnails-src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/WHT.gif" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/product6.jpg"></mj-carousel-image>
+          </mj-carousel>
+        </mj-column>
+      </mj-section>
+      <mj-section>
+        <mj-column width="480px">
+          <mj-text font-family="Open Sans, Arial, sans-serif" font-size="14px" line-height="26px" color="#bcbec0" text-transform="uppercase" align="center">select color</mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-raw>&#60;\!--&#60;![endif]--&#62;</mj-raw>
+      <mj-section padding="10px 0 5px">
+        <mj-column>
+          <mj-button padding="0px" font-family="Open Sans, Arial, sans-serif" href="http://www.ugg.com/" font-size="16px" width="270px" color="#111111" background-color="#f9f9f9"><span style="letter-spacing: 2px; text-transform: uppercase; text-decoration:underline;">shop now
+            </span></mj-button>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="10px 0 30px">
+        <mj-column>
+          <mj-button padding="0px" font-family="Open Sans, Arial, sans-serif" href="http://www.ugg.com/" font-size="16px" width="270px" color="#111111" background-color="#f9f9f9"><span style="letter-spacing: 2px; text-transform: uppercase; text-decoration:underline;">shop in store
+            </span></mj-button>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-wrapper padding="0px">
+      <mj-section background-color="#f9f9f9">
+        <mj-column width="270px">
+          <mj-image href="http://www.ugg.com/" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/secondary.jpg" alt="Guy on a beach with an UGGxGrain surfboard" width="270px"></mj-image>
+        </mj-column>
+        <mj-column width="270px">
+          <mj-text color="#111" font-size="30px" line-height="30px" padding="30px 10px 15px" text-transform="uppercase" font-family="Big Caslon, Garamond, Times, serif" align="center">uggxgrain<br />surfboards<br />giveaway.</mj-text>
+          <mj-text mj-class="body-text" padding="5px 15px">Enter for a chance to win a custom UGGxGrain surfboard and a $200 UGG giftcard.</mj-text>
+          <mj-button background-color="#111" color="#f3b656" font-family="Open Sans, Arial, sans-serif" font-size="16px" align="center" padding="15px 10px" width="190px" height="40px" border-radius="0px" href="http://www.ugg.com/"><span style="text-transform:uppercase; letter-spacing: 2px;">enter to win</span></mj-button>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-wrapper background-color="#f9f9f9" padding="40px 0 0">
+      <mj-section background-color="#f9f9f9">
+        <mj-column>
+          <mj-image src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/rewards-logo-top.gif" alt="Shop rewards" width="600px"></mj-image>
+        </mj-column>
+      </mj-section>
+      <mj-section background-color="#000">
+        <mj-column>
+          <mj-text mj-class="body-text" padding="15px 15px" text-transform="uppercase" font-size="18px" color="#fff">Earn points</mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section background-color="#000">
+        <mj-column>
+          <mj-text mj-class="body-text" padding="5px 15px" color="#fff">When you shop, share, or review products.</mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="10px 0 30px" background-color="#000">
+        <mj-column>
+          <mj-button padding="0px" href="http://www.ugg.com/" font-size="16px" width="270px" color="#fff" background-color="#111" font-family="Open Sans, Arial, sans-serif"><span style="letter-spacing: 2px; text-transform: uppercase; text-decoration:underline;">join now</span></mj-button>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-section padding="25px 0 15px">
+      <mj-column>
+        <mj-image alt="Find a store" href="http://www.ugg.com/" width="168px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/find-a-store.gif"></mj-image>
+      </mj-column>
+    </mj-section>
+    <mj-section padding="10px 0">
+      <mj-column>
+        <mj-button padding="5px 2px" mj-class="open-sans-button" border-radius="0px" href="http://www.ugg.com/women" width="100%"><span style="letter-spacing: 2px;">women</span></mj-button>
+      </mj-column>
+      <mj-column>
+        <mj-button padding="5px 2px" mj-class="open-sans-button" border-radius="0px" href="http://www.ugg.com/men" width="100%"><span style="letter-spacing: 2px;">men</span></mj-button>
+      </mj-column>
+      <mj-column>
+        <mj-button padding="5px 2px" mj-class="open-sans-button" border-radius="0px" href="http://www.ugg.com/kids" width="100%"><span style="letter-spacing: 2px;">kids</span></mj-button>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text font-family="Open Sans, Arial" font-size="16px" align="center" text-transform="uppercase" font-weight="bold" letter-spacing="2px">free shipping. free returns *</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-group>
+        <mj-column>
+          <mj-image alt="ugg facebook" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-facebook.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg instagram" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-instagram.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg snapchat" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-snapchat.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg pinterest" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-pinterest.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg twitter" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-twitter.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg youtube" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-youtube.gif"></mj-image>
+        </mj-column>
+        <mj-column>
+          <mj-image alt="ugg blog" href="http://www.ugg.com/" width="40px" src="https://static.cdn.responsys.net/i2/responsysimages/uggs/contentlibrary/promotional/2017/06-june/20170615_u_royale-b/images/share-blog.gif"></mj-image>
+        </mj-column>
+      </mj-group>
+    </mj-section>
+    <mj-section padding="10px 45px">
+      <mj-group>
+        <mj-column width="27%">
+          <mj-text padding="7px 0" text-transform="uppercase" font-family="Open Sans, Arial, sans-serif" font-size="12px" text-decoration="none" align="center"><a href="http://www.ugg.com/" style="text-decoration:none; color:#111111" class="apple-link-black"><strong>live chat</strong></a></mj-text>
+        </mj-column>
+        <mj-column width="46%">
+          <mj-text padding="7px 0" text-transform="uppercase" font-family="Open Sans, Arial, sans-serif" font-size="11px" text-decoration="none" align="center"><a href="" style="text-decoration:none; color:#111111" class="apple-link-black"><strong>call us</strong>
+              <br />
+              1 (888) 432-8530
+            </a></mj-text>
+        </mj-column>
+        <mj-column width="27%">
+          <mj-text padding="7px 0" text-transform="uppercase" font-family="Open Sans, Arial, sans-serif" font-size="12px" text-decoration="none" align="center"><a href="http://www.ugg.com/" style="text-decoration:none; color:#111111;" class="apple-link-black"><strong>email us</strong></a>
+            <br />
+            <br />
+          </mj-text>
+        </mj-column>
+      </mj-group>
+    </mj-section>
+    <mj-section padding="0px">
+      <mj-column>
+        <mj-text mj-class="footer-text" align="center" padding="0 10px">
+          <p style="Margin:0; padding-bottom:10px; font-size:10px; line-height:15px; Margin-bottom:10px; color:#111111; font-family: 'Open Sans', 'Raleway', Arial, Helvetica, sans-serif;">We only send emails to individuals who have registered at our site:
+            <a href="http://www.ugg.com/" name="footer_ugghomepage" style="color:#111111; text-decoration:underline;">www.ugg.com</a>
+          </p>
+          <p style="Margin:0; padding-bottom:10px; font-size:10px; line-height:15px; Margin-bottom:10px; color:#111111; font-family: 'Open Sans', 'Raleway', Arial, Helvetica, sans-serif;">*A free return label will be included with your order. This offer only applies to full price orders shipped within the continental United States and placed on
+            <span class="apple-link-black">ugg.com</span>. Please note this offer does not apply to clearance product.
+          </p>
+          <p style="Margin:0; padding-bottom:10px; font-size:10px; line-height:15px; Margin-bottom:10px; color:#111111; font-family: 'Open Sans', 'Raleway', Arial, Helvetica, sans-serif;">
+            <span style="color:#111111 !important; text-decoration:none;">
+              <strong>1.888.432.8530</strong>
+              <br /> 123 North Leroux Street, Flagstaff, AZ 86001
+            </span>
+            <br />
+            <a href="http://www.ugg.com/" name="footer_privacy" style="color:#111111; text-decoration:underline;">
+              <strong>Privacy Policy</strong>
+            </a>&#160;&#160;|&#160;&#160;
+            <a href="http://www.ugg.com/" style="text-decoration:underline; color:#111111;">
+              <strong>Unsubscribe</strong>
+            </a>&#160;&#160;|&#160;&#160;
+            <a href="https://email.ugg.com/pub/sf/ResponseForm?_ri_%3DX0Gzc2X%253DYQpglLjHJlTQGjmR9kDzfwzbMzackp9f3F8d45ze2zfbW8hYB6AzgB7gaIYB3tN5qwvasVXMtX%253DYQpglLjHJlTQGNXlMNF3fFUYHWCzdBj2rGzgJpzem2KonGoezgzbfUyABevzgl4CepTMC%26_ei_%3DEolaGGF4SNMvxFF7KucKuWP7XpARYKtbBY43fLBYxvXNpGx2Z89j4M" style="text-decoration:underline; color:#111111;">View in Browser</a>
+          </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/HtmlKit.sln
+++ b/HtmlKit.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeGenerator", "CodeGenera
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "UnitTests\UnitTests.csproj", "{983A05E3-0188-4642-8315-EAAF8C17690F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{82FFCA9B-3AB6-4C72-BF67-6DC7FD756B91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{983A05E3-0188-4642-8315-EAAF8C17690F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{983A05E3-0188-4642-8315-EAAF8C17690F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{983A05E3-0188-4642-8315-EAAF8C17690F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82FFCA9B-3AB6-4C72-BF67-6DC7FD756B91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82FFCA9B-3AB6-4C72-BF67-6DC7FD756B91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82FFCA9B-3AB6-4C72-BF67-6DC7FD756B91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82FFCA9B-3AB6-4C72-BF67-6DC7FD756B91}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HtmlKit/CharBuffer - Copy.cs
+++ b/HtmlKit/CharBuffer - Copy.cs
@@ -1,0 +1,126 @@
+﻿//
+// CharBuffer.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2015-2023 Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace HtmlKit {
+	class CharBuffer2
+	{
+		char[] buffer;
+		int start;
+		int length;
+
+		public CharBuffer2 (int capacity)
+		{
+			buffer = new char[capacity];
+		}
+
+		public int Capacity {
+			get => buffer.Length;
+		}
+
+		public void Reset()
+		{
+			start = 0;
+			length = 0;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Next()
+		{
+			start += length;
+			length = 0;
+		}
+
+		public int Length {
+			[MethodImpl (MethodImplOptions.AggressiveInlining)]
+			get => length;
+		}
+
+		public char this[int index] {
+			[MethodImpl (MethodImplOptions.AggressiveInlining)]
+			get { return buffer[index]; }
+			[MethodImpl (MethodImplOptions.AggressiveInlining)]
+			set { buffer[index] = value; }
+		}
+
+		public void MoveBack()
+		{
+			length--;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		void EnsureCapacity (int length)
+		{
+			int totalLength = start + length;
+			if (totalLength < buffer.Length)
+				return;
+
+			int capacity = buffer.Length << 1;
+			while (capacity <= totalLength)
+				capacity <<= 1;
+
+			Array.Resize (ref buffer, capacity);
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Append (char c)
+		{
+			EnsureCapacity (Length + 1);
+			buffer[start + length++] = c;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public void Append (string str)
+		{
+			EnsureCapacity (Length + str.Length);
+			str.CopyTo (0, buffer, start + length, str.Length);
+			length += str.Length;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		public override string ToString ()
+		{
+#if NETSTANDARD2_0
+			unsafe {
+				fixed (char* pointer = buffer) {
+					return new string (pointer, start, Length);
+				}
+			}
+#else
+			ReadOnlySpan<char> slice = buffer.AsSpan ().Slice (start, length);
+
+			return new string (slice);
+#endif
+		}
+
+		//public static implicit operator string (CharBuffer buffer)
+		//{
+		//	return buffer.ToString ();
+		//}
+	}
+}

--- a/HtmlKit/CharBufferPoolPolicy.cs
+++ b/HtmlKit/CharBufferPoolPolicy.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.ObjectPool;
+
+namespace HtmlKit
+{
+	internal sealed class CharBufferPoolPolicy : IPooledObjectPolicy<CharBuffer2>
+	{
+		private const int MaxSize = 4 * 1024 * 1024;
+
+		public CharBuffer2 Create ()
+		{
+			return new CharBuffer2 (MaxSize);
+		}
+
+		public bool Return (CharBuffer2 obj)
+		{
+			obj.Reset ();
+			return obj.Capacity == MaxSize;
+		}
+	}
+}

--- a/HtmlKit/HtmlAttribute.cs
+++ b/HtmlKit/HtmlAttribute.cs
@@ -53,7 +53,7 @@ namespace HtmlKit {
 
 			Name = id.ToAttributeName ();
 			Value = value;
-			Id = id;
+			this.id = id;
 		}
 
 		/// <summary>
@@ -78,7 +78,6 @@ namespace HtmlKit {
 			if (!HtmlUtils.IsValidTokenName (name))
 				throw new ArgumentException ("Invalid attribute name.", nameof (name));
 
-			Id = name.ToHtmlAttributeId ();
 			Value = value;
 			Name = name;
 		}
@@ -91,9 +90,10 @@ namespace HtmlKit {
 			if (name.Length == 0)
 				throw new ArgumentException ("The attribute name cannot be empty.", nameof (name));
 
-			Id = name.ToHtmlAttributeId ();
 			Name = name;
 		}
+
+		private HtmlAttributeId id = (HtmlAttributeId) (-1);
 
 		/// <summary>
 		/// Get the HTML attribute identifier.
@@ -103,7 +103,13 @@ namespace HtmlKit {
 		/// </remarks>
 		/// <value>The attribute identifier.</value>
 		public HtmlAttributeId Id {
-			get; private set;
+			get {
+				if (id < 0) {
+					id = Name.ToHtmlAttributeId ();
+				}
+
+				return id;
+			}
 		}
 
 		/// <summary>

--- a/HtmlKit/HtmlKit.csproj
+++ b/HtmlKit/HtmlKit.csproj
@@ -8,7 +8,7 @@
     <Authors>Jeffrey Stedfast</Authors>
     <_LegacyFrameworks>net462;net47</_LegacyFrameworks>
     <_LegacyFrameworks Condition=" Exists('C:\Windows') ">$(_LegacyFrameworks);net48</_LegacyFrameworks>
-    <TargetFrameworks>$(_LegacyFrameworks);netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>HtmlKit</AssemblyName>
@@ -51,6 +51,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="CharBuffer - Copy.cs" />
+    <Compile Include="CharBufferPoolPolicy.cs" />
+    <Compile Include="HtmlTokenizer2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CharBuffer.cs" />
     <Compile Include="HtmlAttribute.cs" />
@@ -70,6 +73,10 @@
     <Compile Include="HtmlWriter.cs" />
     <Compile Include="HtmlWriterState.cs" />
     <Compile Include="OptimizedOrdinalComparer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.4" />
   </ItemGroup>
 
 </Project>

--- a/HtmlKit/HtmlToken.cs
+++ b/HtmlKit/HtmlToken.cs
@@ -386,7 +386,6 @@ namespace HtmlKit {
 
 			Attributes = new HtmlAttributeCollection (attributes);
 			IsEmptyElement = isEmptyElement;
-			Id = name.ToHtmlTagId ();
 			Name = name;
 		}
 
@@ -407,7 +406,6 @@ namespace HtmlKit {
 				throw new ArgumentNullException (nameof (name));
 
 			Attributes = new HtmlAttributeCollection ();
-			Id = name.ToHtmlTagId ();
 			IsEndTag = isEndTag;
 			Name = name;
 		}
@@ -423,6 +421,8 @@ namespace HtmlKit {
 			get; private set;
 		}
 
+		private HtmlTagId id = (HtmlTagId) (-1);
+
 		/// <summary>
 		/// Get the HTML tag identifier.
 		/// </summary>
@@ -431,7 +431,13 @@ namespace HtmlKit {
 		/// </remarks>
 		/// <value>The HTML tag identifier.</value>
 		public HtmlTagId Id {
-			get; private set;
+			get {
+				if (id < 0) {
+					id = Name.ToHtmlTagId ();
+				}
+
+				return id;
+			}
 		}
 
 		/// <summary>

--- a/HtmlKit/HtmlTokenizer2.cs
+++ b/HtmlKit/HtmlTokenizer2.cs
@@ -1,0 +1,2954 @@
+﻿//
+// HtmlTokenizer.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2015-2023 Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace HtmlKit {
+	/// <summary>
+	/// An HTML tokenizer.
+	/// </summary>
+	/// <remarks>
+	/// Tokenizes HTML text, emitting an <see cref="HtmlToken"/> for each token it encounters.
+	/// </remarks>
+	public class HtmlTokenizer2 : IDisposable
+	{
+		// Specification: https://dev.w3.org/html5/spec-LC/tokenization.html
+		const string DocType = "doctype";
+		const string CData = "[CDATA[";
+
+		private static readonly ObjectPool<CharBuffer2> bufferPool = new DefaultObjectPool<CharBuffer2> (new CharBufferPoolPolicy());
+		readonly HtmlEntityDecoder entity = new HtmlEntityDecoder ();
+		readonly CharBuffer2 data;
+		readonly CharBuffer2 name;
+		readonly TextReader text;
+		readonly char[] cdata = new char[3];
+		HtmlDocTypeToken doctype;
+		HtmlAttribute attribute;
+		string activeTagName;
+		HtmlTagToken tag;
+		int cdataIndex;
+		bool isEndTag;
+		bool bang;
+		char quote;
+
+		/// <summary>
+		/// Initialize a new instance of the <see cref="HtmlTokenizer"/> class.
+		/// </summary>
+		/// <remarks>
+		/// Creates a new <see cref="HtmlTokenizer"/>.
+		/// </remarks>
+		/// <param name="reader">The <see cref="TextReader"/>.</param>
+		public HtmlTokenizer2 (TextReader reader)
+		{
+			DecodeCharacterReferences = true;
+			LinePosition = 1;
+			LineNumber = 1;
+			text = reader;
+
+			name = bufferPool.Get ();
+			data = bufferPool.Get ();
+		}
+
+		/// <inheritdoc />
+		public void Dispose ()
+		{
+			bufferPool.Return (data);
+			bufferPool.Return (name);
+		}
+
+		/// <summary>
+		/// Get or set whether or not the tokenizer should decode character references.
+		/// </summary>
+		/// <remarks>
+		/// <para>Gets or sets whether or not the tokenizer should decode character references.</para>
+		/// <note type="warning">Character references in attribute values will still be decoded
+		/// even if this value is set to <c>false</c>.</note>
+		/// </remarks>
+		/// <value><c>true</c> if character references should be decoded; otherwise, <c>false</c>.</value>
+		public bool DecodeCharacterReferences {
+			get; set;
+		}
+
+		/// <summary>
+		/// Get the current HTML namespace detected by the tokenizer.
+		/// </summary>
+		/// <remarks>
+		/// Gets the current HTML namespace detected by the tokenizer.
+		/// </remarks>
+		/// <value>The html namespace.</value>
+		public HtmlNamespace HtmlNamespace {
+			get; private set;
+		}
+
+		/// <summary>
+		/// Get or set whether or not the tokenizer should ignore truncated tags.
+		/// </summary>
+		/// <remarks>
+		/// <para>Gets or sets whether or not the tokenizer should ignore truncated tags.</para>
+		/// <para>If <c>false</c> and the stream abruptly ends in the middle of an HTML tag, it will be
+		/// treated as an <see cref="HtmlDataToken"/> instead.</para>
+		/// </remarks>
+		/// <value><c>true</c> if truncated tags should be ignored; otherwise, <c>false</c>.</value>
+		public bool IgnoreTruncatedTags {
+			get; set;
+		}
+
+		/// <summary>
+		/// Get the current line number.
+		/// </summary>
+		/// <remarks>
+		/// <para>This property is most commonly used for error reporting, but can be called
+		/// at any time. The starting value for this property is <c>1</c>.</para>
+		/// <para>Combined with <see cref="LinePosition"/>, a value of <c>1,1</c> indicates
+		/// the start of the document.</para>
+		/// </remarks>
+		/// <value>The current line number.</value>
+		public int LineNumber {
+			get; private set;
+		}
+
+		/// <summary>
+		/// Get the current line position.
+		/// </summary>
+		/// <remarks>
+		/// <para>This property is most commonly used for error reporting, but can be called
+		/// at any time. The starting value for this property is <c>1</c>.</para>
+		/// <para>Combined with <see cref="LineNumber"/>, a value of <c>1,1</c> indicates
+		/// the start of the document.</para>
+		/// </remarks>
+		/// <value>The column position of the current line.</value>
+		public int LinePosition {
+			get; private set;
+		}
+
+		/// <summary>
+		/// Get the current state of the tokenizer.
+		/// </summary>
+		/// <remarks>
+		/// Gets the current state of the tokenizer.
+		/// </remarks>
+		/// <value>The current state of the tokenizer.</value>
+		public HtmlTokenizerState TokenizerState {
+			get; private set;
+		}
+
+		/// <summary>
+		/// Create a DOCTYPE token.
+		/// </summary>
+		/// <remarks>
+		/// Creates a DOCTYPE token.
+		/// </remarks>
+		/// <returns>The DOCTYPE token.</returns>
+		protected virtual HtmlDocTypeToken CreateDocType ()
+		{
+			return new HtmlDocTypeToken ();
+		}
+
+		HtmlDocTypeToken CreateDocTypeToken (string rawTagName)
+		{
+			var token = CreateDocType ();
+			token.RawTagName = rawTagName;
+			return token;
+		}
+
+		/// <summary>
+		/// Create an HTML comment token.
+		/// </summary>
+		/// <remarks>
+		/// Creates an HTML comment token.
+		/// </remarks>
+		/// <returns>The HTML comment token.</returns>
+		/// <param name="comment">The comment.</param>
+		/// <param name="bogus"><c>true</c> if the comment is bogus; otherwise, <c>false</c>.</param>
+		protected virtual HtmlCommentToken CreateCommentToken (string comment, bool bogus = false)
+		{
+			return new HtmlCommentToken (comment, bogus);
+		}
+
+		/// <summary>
+		/// Create an HTML character data token.
+		/// </summary>
+		/// <remarks>
+		/// Creates an HTML character data token.
+		/// </remarks>
+		/// <returns>The HTML character data token.</returns>
+		/// <param name="data">The character data.</param>
+		protected virtual HtmlDataToken CreateDataToken (string data)
+		{
+			return new HtmlDataToken (data);
+		}
+
+		/// <summary>
+		/// Create an HTML character data token.
+		/// </summary>
+		/// <remarks>
+		/// Creates an HTML character data token.
+		/// </remarks>
+		/// <returns>The HTML character data token.</returns>
+		/// <param name="data">The character data.</param>
+		protected virtual HtmlCDataToken CreateCDataToken (string data)
+		{
+			return new HtmlCDataToken (data);
+		}
+
+		/// <summary>
+		/// Create an HTML script data token.
+		/// </summary>
+		/// <remarks>
+		/// Creates an HTML script data token.
+		/// </remarks>
+		/// <returns>The HTML script data token.</returns>
+		/// <param name="data">The script data.</param>
+		protected virtual HtmlScriptDataToken CreateScriptDataToken (string data)
+		{
+			return new HtmlScriptDataToken (data);
+		}
+
+		/// <summary>
+		/// Create an HTML tag token.
+		/// </summary>
+		/// <remarks>
+		/// Creates an HTML tag token.
+		/// </remarks>
+		/// <returns>The HTML tag token.</returns>
+		/// <param name="name">The tag name.</param>
+		/// <param name="isEndTag"><c>true</c> if the tag is an end tag; otherwise, <c>false</c>.</param>
+		protected virtual HtmlTagToken CreateTagToken (string name, bool isEndTag = false)
+		{
+			return new HtmlTagToken (name, isEndTag);
+		}
+
+		/// <summary>
+		/// Create an attribute.
+		/// </summary>
+		/// <remarks>
+		/// Creates an attribute.
+		/// </remarks>
+		/// <returns>The attribute.</returns>
+		/// <param name="name">The attribute name.</param>
+		protected virtual HtmlAttribute CreateAttribute (string name)
+		{
+			return new HtmlAttribute (name);
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		static bool IsAlphaNumeric (int c)
+		{
+			return ((uint) (c - 'A') <= 'Z' - 'A') || ((uint) (c - 'a') <= 'z' - 'a') || ((uint) (c - '0') <= '9' - '0');
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		static bool IsAsciiLetter (int c)
+		{
+			return ((uint) (c - 'A') <= 'Z' - 'A') || ((uint) (c - 'a') <= 'z' - 'a');
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		static char ToLower (int c)
+		{
+			// check if the char is within the uppercase range
+			if ((uint) (c - 'A') <= 'Z' - 'A')
+				return (char) (c + 0x20);
+
+			return (char) c;
+		}
+
+		int Peek ()
+		{
+			return text.Peek ();
+		}
+
+		int Read ()
+		{
+			int c;
+
+			if ((c = text.Read ()) == -1)
+				return -1;
+
+			if (c == '\n') {
+				LinePosition = 1;
+				LineNumber++;
+			} else {
+				LinePosition++;
+			}
+
+			return c;
+		}
+
+		// Note: value must be lowercase
+		bool NameIs (string value)
+		{
+			if (name.Length != value.Length)
+				return false;
+
+			for (int i = 0; i < name.Length; i++) {
+				if (ToLower (name[i]) != value[i])
+					return false;
+			}
+
+			return true;
+		}
+
+		void EmitTagAttribute ()
+		{
+			attribute = CreateAttribute (name.ToString ());
+			tag.Attributes.Add (attribute);
+			name.Next();
+		}
+
+		HtmlToken EmitCommentToken (string comment, bool bogus = false)
+		{
+			var token = CreateCommentToken (comment, bogus);
+			token.IsBangComment = bang;
+			data.Next();
+			name.Next();
+			bang = false;
+			return token;
+		}
+
+		HtmlToken EmitCommentToken (CharBuffer2 comment, bool bogus = false)
+		{
+			return EmitCommentToken (comment.ToString (), bogus);
+		}
+
+		HtmlToken EmitDocType ()
+		{
+			var token = doctype;
+			data.Next();
+			doctype = null;
+			return token;
+		}
+
+		HtmlToken EmitDataToken (bool encodeEntities, bool truncated)
+		{
+			if (data.Length == 0)
+				return null;
+
+			if (truncated && IgnoreTruncatedTags) {
+				data.Next();
+				return null;
+			}
+
+			var token = CreateDataToken (data.ToString ());
+			token.EncodeEntities = encodeEntities;
+			data.Next();
+
+			return token;
+		}
+
+		HtmlToken EmitCDataToken ()
+		{
+			if (data.Length == 0)
+				return null;
+
+			var token = CreateCDataToken (data.ToString ());
+			data.Next();
+
+			return token;
+		}
+
+		HtmlToken EmitScriptDataToken ()
+		{
+			if (data.Length == 0)
+				return null;
+
+			var token = CreateScriptDataToken (data.ToString ());
+			data.Next();
+
+			return token;
+		}
+
+		HtmlToken EmitTagToken ()
+		{
+			if (!tag.IsEndTag && !tag.IsEmptyElement) {
+				switch (tag.Id) {
+				case HtmlTagId.Style: case HtmlTagId.Xmp: case HtmlTagId.IFrame: case HtmlTagId.NoEmbed: case HtmlTagId.NoFrames:
+					TokenizerState = HtmlTokenizerState.RawText;
+					activeTagName = tag.Name.ToLowerInvariant ();
+					break;
+				case HtmlTagId.Title: case HtmlTagId.TextArea:
+					TokenizerState = HtmlTokenizerState.RcData;
+					activeTagName = tag.Name.ToLowerInvariant ();
+					break;
+				case HtmlTagId.PlainText:
+					TokenizerState = HtmlTokenizerState.PlainText;
+					break;
+				case HtmlTagId.Script:
+					TokenizerState = HtmlTokenizerState.ScriptData;
+					break;
+				case HtmlTagId.NoScript:
+					// TODO: only switch into the RawText state if scripting is enabled
+					TokenizerState = HtmlTokenizerState.RawText;
+					activeTagName = tag.Name.ToLowerInvariant ();
+					break;
+				case HtmlTagId.Html:
+					TokenizerState = HtmlTokenizerState.Data;
+
+					for (int i = tag.Attributes.Count; i > 0; i--) {
+						var attr = tag.Attributes[i - 1];
+
+						if (attr.Id == HtmlAttributeId.XmlNS && attr.Value != null) {
+							HtmlNamespace = attr.Value.ToHtmlNamespace ();
+							break;
+						}
+					}
+					break;
+				default:
+					TokenizerState = HtmlTokenizerState.Data;
+					break;
+				}
+			} else {
+				TokenizerState = HtmlTokenizerState.Data;
+			}
+
+			var token = tag;
+			data.Next();
+			tag = null;
+
+			return token;
+		}
+
+		// 8.2.4.69 Tokenizing character references
+		HtmlToken ReadCharacterReference (HtmlTokenizerState next)
+		{
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				data.Append ('&');
+
+				return EmitDataToken (true, false);
+			}
+
+			c = (char) nc;
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ': case '<': case '&':
+				// no character is consumed, emit '&'
+				TokenizerState = next;
+				data.Append ('&');
+				return null;
+			}
+
+			entity.Push ('&');
+
+			while (entity.Push (c)) {
+				Read ();
+
+				if (c == ';')
+					break;
+
+				if ((nc = Peek ()) == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					data.Append (entity.GetPushedInput ());
+					entity.Reset ();
+
+					return EmitDataToken (true, false);
+				}
+
+				c = (char) nc;
+			}
+
+			TokenizerState = next;
+
+			data.Append (entity.GetValue ());
+			entity.Reset ();
+
+			return null;
+		}
+
+		HtmlToken ReadGenericRawTextLessThan (HtmlTokenizerState rawText, HtmlTokenizerState rawTextEndTagOpen)
+		{
+			int nc = Peek ();
+
+			data.Append ('<');
+
+			switch ((char) nc) {
+			case '/':
+				TokenizerState = rawTextEndTagOpen;
+				data.Append ('/');
+				name.Next();
+				Read ();
+				break;
+			default:
+				TokenizerState = rawText;
+				break;
+			}
+
+			return null;
+		}
+
+		HtmlToken ReadGenericRawTextEndTagOpen (bool decoded, HtmlTokenizerState rawText, HtmlTokenizerState rawTextEndTagName)
+		{
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitDataToken (decoded, true);
+			}
+
+			c = (char) nc;
+
+			if (IsAsciiLetter (c)) {
+				TokenizerState = rawTextEndTagName;
+				name.Append (c);
+				data.Append (c);
+				Read ();
+			} else {
+				TokenizerState = rawText;
+			}
+
+			return null;
+		}
+
+		HtmlToken ReadGenericRawTextEndTagName (bool decoded, HtmlTokenizerState rawText)
+		{
+			var current = TokenizerState;
+
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitDataToken (decoded, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					if (NameIs (activeTagName)) {
+						TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+						break;
+					}
+
+					goto default;
+				case '/':
+					if (NameIs (activeTagName)) {
+						TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+						break;
+					}
+					goto default;
+				case '>':
+					if (NameIs (activeTagName)) {
+						var token = CreateTagToken (name.ToString (), true);
+						TokenizerState = HtmlTokenizerState.Data;
+						data.Next();
+						name.Next();
+						return token;
+					}
+					goto default;
+				default:
+					if (!IsAsciiLetter (c)) {
+						TokenizerState = rawText;
+						return null;
+					}
+
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == current);
+
+			tag = CreateTagToken (name.ToString (), true);
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.1 Data state
+		HtmlToken ReadData ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					break;
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '&':
+					if (DecodeCharacterReferences) {
+						TokenizerState = HtmlTokenizerState.CharacterReferenceInData;
+						return null;
+					}
+
+					goto default;
+				case '<':
+					TokenizerState = HtmlTokenizerState.TagOpen;
+					break;
+				//case 0: // parse error, but emit it anyway
+				default:
+					data.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.Data);
+
+			return EmitDataToken (DecodeCharacterReferences, false);
+		}
+
+		// 8.2.4.2 Character reference in data state
+		HtmlToken ReadCharacterReferenceInData ()
+		{
+			return ReadCharacterReference (HtmlTokenizerState.Data);
+		}
+
+		// 8.2.4.3 RCDATA state
+		HtmlToken ReadRcData ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					break;
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '&':
+					if (DecodeCharacterReferences) {
+						TokenizerState = HtmlTokenizerState.CharacterReferenceInRcData;
+						return null;
+					}
+
+					goto default;
+				case '<':
+					TokenizerState = HtmlTokenizerState.RcDataLessThan;
+					return EmitDataToken (DecodeCharacterReferences, false);
+				default:
+					data.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.RcData);
+
+			return EmitDataToken (DecodeCharacterReferences, false);
+		}
+
+		// 8.2.4.4 Character reference in RCDATA state
+		HtmlToken ReadCharacterReferenceInRcData ()
+		{
+			return ReadCharacterReference (HtmlTokenizerState.RcData);
+		}
+
+		// 8.2.4.5 RAWTEXT state
+		HtmlToken ReadRawText ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					break;
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '<':
+					TokenizerState = HtmlTokenizerState.RawTextLessThan;
+					return EmitDataToken (false, false);
+				default:
+					data.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.RawText);
+
+			return EmitDataToken (false, false);
+		}
+
+		// 8.2.4.6 Script data state
+		HtmlToken ReadScriptData ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					break;
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '<':
+					TokenizerState = HtmlTokenizerState.ScriptDataLessThan;
+					break;
+				default:
+					data.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptData);
+
+			return EmitScriptDataToken ();
+		}
+
+		// 8.2.4.7 PLAINTEXT state
+		HtmlToken ReadPlainText ()
+		{
+			int nc = Read ();
+
+			while (nc != -1) {
+				char c = (char) nc;
+
+				data.Append (c == '\0' ? '\uFFFD' : c);
+				nc = Read ();
+			}
+
+			TokenizerState = HtmlTokenizerState.EndOfFile;
+
+			return EmitDataToken (false, false);
+		}
+
+		// 8.2.4.8 Tag open state
+		HtmlToken ReadTagOpen ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				var token = IgnoreTruncatedTags ? null : CreateDataToken ("<");
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return token;
+			}
+
+			c = (char) nc;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append ('<');
+			data.Append (c);
+
+			switch ((c = (char) nc)) {
+			case '!':
+				TokenizerState = HtmlTokenizerState.MarkupDeclarationOpen;
+				break;
+			case '?':
+				TokenizerState = HtmlTokenizerState.BogusComment;
+				data.Next ();
+				data.Append (c);
+				break;
+			case '/':
+				TokenizerState = HtmlTokenizerState.EndTagOpen;
+				break;
+			default:
+				if (IsAsciiLetter (c)) {
+					TokenizerState = HtmlTokenizerState.TagName;
+					isEndTag = false;
+					name.Append (c);
+				} else {
+					TokenizerState = HtmlTokenizerState.Data;
+				}
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.9 End tag open state
+		HtmlToken ReadEndTagOpen ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitDataToken (false, true);
+			}
+
+			c = (char) nc;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append (c);
+
+			switch (c) {
+			case '>': // parse error
+				TokenizerState = HtmlTokenizerState.Data;
+				data.Next(); // FIXME: this is probably wrong
+				break;
+			default:
+				if (IsAsciiLetter (c)) {
+					TokenizerState = HtmlTokenizerState.TagName;
+					isEndTag = true;
+					name.Append (c);
+				} else {
+					TokenizerState = HtmlTokenizerState.BogusComment;
+					data.Next ();
+					data.Append (c);
+				}
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.10 Tag name state
+		HtmlToken ReadTagName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+					break;
+				case '/':
+					TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+					break;
+				case '>':
+					tag = CreateTagToken (name.ToString (), isEndTag);
+					data.Next();
+					name.Next();
+
+					return EmitTagToken ();
+				default:
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.TagName);
+
+			tag = CreateTagToken (name.ToString (), isEndTag);
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.11 RCDATA less-than sign state
+		HtmlToken ReadRcDataLessThan ()
+		{
+			return ReadGenericRawTextLessThan (HtmlTokenizerState.RcData, HtmlTokenizerState.RcDataEndTagOpen);
+		}
+
+		// 8.2.4.12 RCDATA end tag open state
+		HtmlToken ReadRcDataEndTagOpen ()
+		{
+			return ReadGenericRawTextEndTagOpen (DecodeCharacterReferences, HtmlTokenizerState.RcData, HtmlTokenizerState.RcDataEndTagName);
+		}
+
+		// 8.2.4.13 RCDATA end tag name state
+		HtmlToken ReadRcDataEndTagName ()
+		{
+			return ReadGenericRawTextEndTagName (DecodeCharacterReferences, HtmlTokenizerState.RcData);
+		}
+
+		// 8.2.4.14 RAWTEXT less-than sign state
+		HtmlToken ReadRawTextLessThan ()
+		{
+			return ReadGenericRawTextLessThan (HtmlTokenizerState.RawText, HtmlTokenizerState.RawTextEndTagOpen);
+		}
+
+		// 8.2.4.15 RAWTEXT end tag open state
+		HtmlToken ReadRawTextEndTagOpen ()
+		{
+			return ReadGenericRawTextEndTagOpen (false, HtmlTokenizerState.RawText, HtmlTokenizerState.RawTextEndTagName);
+		}
+
+		// 8.2.4.16 RAWTEXT end tag name state
+		HtmlToken ReadRawTextEndTagName ()
+		{
+			return ReadGenericRawTextEndTagName (false, HtmlTokenizerState.RawText);
+		}
+
+		// 8.2.4.17 Script data less-than sign state
+		HtmlToken ReadScriptDataLessThan ()
+		{
+			int nc = Peek ();
+
+			data.Append ('<');
+
+			switch ((char) nc) {
+			case '/':
+				TokenizerState = HtmlTokenizerState.ScriptDataEndTagOpen;
+				data.Append ('/');
+				name.Next();
+				Read ();
+				break;
+			case '!':
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapeStart;
+				data.Append ('!');
+				Read ();
+				break;
+			default:
+				TokenizerState = HtmlTokenizerState.ScriptData;
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.18 Script data end tag open state
+		HtmlToken ReadScriptDataEndTagOpen ()
+		{
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitScriptDataToken ();
+			}
+
+			c = (char) nc;
+
+			if (c == 'S' || c == 's') {
+				TokenizerState = HtmlTokenizerState.ScriptDataEndTagName;
+				name.Append ('s');
+				data.Append (c);
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptData;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.19 Script data end tag name state
+		HtmlToken ReadScriptDataEndTagName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					if (NameIs ("script")) {
+						TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+						break;
+					}
+					goto default;
+				case '/':
+					if (NameIs ("script")) {
+						TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+						break;
+					}
+					goto default;
+				case '>':
+					if (NameIs ("script")) {
+						var token = CreateTagToken (name.ToString (), true);
+						TokenizerState = HtmlTokenizerState.Data;
+						data.Next();
+						name.Next();
+						return token;
+					}
+					goto default;
+				default:
+					if (!IsAsciiLetter (c)) {
+						TokenizerState = HtmlTokenizerState.ScriptData;
+						name.Next();
+						return null;
+					}
+
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEndTagName);
+
+			tag = CreateTagToken (name.ToString (), true);
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.20 Script data escape start state
+		HtmlToken ReadScriptDataEscapeStart ()
+		{
+			int nc = Peek ();
+
+			if (nc == '-') {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapeStartDash;
+				data.Append ('-');
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptData;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.21 Script data escape start dash state
+		HtmlToken ReadScriptDataEscapeStartDash ()
+		{
+			int nc = Peek ();
+
+			if (nc == '-') {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapedDashDash;
+				data.Append ('-');
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptData;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.22 Script data escaped state
+		HtmlToken ReadScriptDataEscaped ()
+		{
+			HtmlToken token = null;
+
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '-':
+					TokenizerState = HtmlTokenizerState.ScriptDataEscapedDash;
+					data.Append ('-');
+					break;
+				case '<':
+					TokenizerState = HtmlTokenizerState.ScriptDataEscapedLessThan;
+					token = EmitScriptDataToken ();
+					data.Append ('<');
+					break;
+				default:
+					data.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEscaped);
+
+			return token;
+		}
+
+		// 8.2.4.23 Script data escaped dash state
+		HtmlToken ReadScriptDataEscapedDash ()
+		{
+			HtmlToken token = null;
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitScriptDataToken ();
+			}
+
+			switch ((c = (char) nc)) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapedDashDash;
+				data.Append ('-');
+				Read ();
+				break;
+			case '<':
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapedLessThan;
+				token = EmitScriptDataToken ();
+				data.Append ('<');
+				Read ();
+				break;
+			default:
+				TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+				data.Append (c == '\0' ? '\uFFFD' : c);
+				Read ();
+				break;
+			}
+
+			return token;
+		}
+
+		// 8.2.4.24 Script data escaped dash dash state
+		HtmlToken ReadScriptDataEscapedDashDash ()
+		{
+			HtmlToken token = null;
+
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '-':
+					data.Append ('-');
+					break;
+				case '<':
+					TokenizerState = HtmlTokenizerState.ScriptDataEscapedLessThan;
+					token = EmitScriptDataToken ();
+					data.Append ('<');
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.ScriptData;
+					data.Append ('>');
+					break;
+				default:
+					TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+					data.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEscapedDashDash);
+
+			return token;
+		}
+
+		// 8.2.4.25 Script data escaped less-than sign state
+		HtmlToken ReadScriptDataEscapedLessThan ()
+		{
+			int nc = Peek ();
+			char c = (char) nc;
+
+			if (c == '/') {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapedEndTagOpen;
+				data.Append (c);
+				name.Next();
+				Read ();
+			} else if (IsAsciiLetter (c)) {
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapeStart;
+				data.Append (c);
+				name.Append (c);
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.26 Script data escaped end tag open state
+		HtmlToken ReadScriptDataEscapedEndTagOpen ()
+		{
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitScriptDataToken ();
+			}
+
+			c = (char) nc;
+
+			if (IsAsciiLetter (c)) {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscapedEndTagName;
+				data.Append (c);
+				name.Append (c);
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.27 Script data escaped end tag name state
+		HtmlToken ReadScriptDataEscapedEndTagName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					if (NameIs ("script")) {
+						TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+						break;
+					}
+
+					goto default;
+				case '/':
+					if (NameIs ("script")) {
+						TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+						break;
+					}
+					goto default;
+				case '>':
+					if (NameIs ("script")) {
+						var token = CreateTagToken (name.ToString (), true);
+						TokenizerState = HtmlTokenizerState.Data;
+						data.Next();
+						name.Next();
+						return token;
+					}
+					goto default;
+				default:
+					if (!IsAsciiLetter (c)) {
+						TokenizerState = HtmlTokenizerState.ScriptData;
+						return null;
+					}
+
+					name.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEscapedEndTagName);
+
+			tag = CreateTagToken (name.ToString (), true);
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.28 Script data double escape start state
+		HtmlToken ReadScriptDataDoubleEscapeStart ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ': case '/': case '>':
+					if (NameIs ("script"))
+						TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+					else
+						TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+					name.Next();
+					break;
+				default:
+					if (!IsAsciiLetter (c))
+						TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+					else
+						name.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataDoubleEscapeStart);
+
+			return null;
+		}
+
+		// 8.2.4.29 Script data double escaped state
+		HtmlToken ReadScriptDataDoubleEscaped ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '-':
+					TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapedDash;
+					data.Append ('-');
+					break;
+				case '<':
+					TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapedLessThan;
+					data.Append ('<');
+					break;
+				default:
+					data.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEscaped);
+
+			return null;
+		}
+
+		// 8.2.4.30 Script data double escaped dash state
+		HtmlToken ReadScriptDataDoubleEscapedDash ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitScriptDataToken ();
+			}
+
+			switch ((c = (char) nc)) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapedDashDash;
+				data.Append ('-');
+				break;
+			case '<':
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapedLessThan;
+				data.Append ('<');
+				break;
+			default:
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+				data.Append (c == '\0' ? '\uFFFD' : c);
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.31 Script data double escaped dash dash state
+		HtmlToken ReadScriptDataDoubleEscapedDashDash ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitScriptDataToken ();
+				}
+
+				c = (char) nc;
+
+				switch (c) {
+				case '-':
+					data.Append ('-');
+					break;
+				case '<':
+					TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapedLessThan;
+					data.Append ('<');
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.ScriptData;
+					data.Append ('>');
+					break;
+				default:
+					TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+					data.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataEscapedDashDash);
+
+			return null;
+		}
+
+		// 8.2.4.32 Script data double escaped less-than sign state
+		HtmlToken ReadScriptDataDoubleEscapedLessThan ()
+		{
+			int nc = Peek ();
+
+			if (nc == '/') {
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscapeEnd;
+				data.Append ('/');
+				Read ();
+			} else {
+				TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.33 Script data double escape end state
+		HtmlToken ReadScriptDataDoubleEscapeEnd ()
+		{
+			do {
+				int nc = Peek ();
+				char c = (char) nc;
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ': case '/': case '>':
+					if (NameIs ("script"))
+						TokenizerState = HtmlTokenizerState.ScriptDataEscaped;
+					else
+						TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+					data.Append (c);
+					Read ();
+					break;
+				default:
+					if (!IsAsciiLetter (c)) {
+						TokenizerState = HtmlTokenizerState.ScriptDataDoubleEscaped;
+					} else {
+						name.Append (c);
+						data.Append (c);
+						Read ();
+					}
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.ScriptDataDoubleEscapeEnd);
+
+			return null;
+		}
+
+		// 8.2.4.34 Before attribute name state
+		HtmlToken ReadBeforeAttributeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					tag = null;
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '/':
+					TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+					return null;
+				case '>':
+					return EmitTagToken ();
+				case '"': case '\'': case '<': case '=':
+					// parse error
+					goto default;
+				default:
+					TokenizerState = HtmlTokenizerState.AttributeName;
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.35 Attribute name state
+		HtmlToken ReadAttributeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+					tag = null;
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					TokenizerState = HtmlTokenizerState.AfterAttributeName;
+					break;
+				case '/':
+					TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+					break;
+				case '=':
+					TokenizerState = HtmlTokenizerState.BeforeAttributeValue;
+					break;
+				case '>':
+					EmitTagAttribute ();
+
+					return EmitTagToken ();
+				default:
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.AttributeName);
+
+			EmitTagAttribute ();
+
+			return null;
+		}
+
+		// 8.2.4.36 After attribute name state
+		HtmlToken ReadAfterAttributeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					tag = null;
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '/':
+					TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+					return null;
+				case '=':
+					TokenizerState = HtmlTokenizerState.BeforeAttributeValue;
+					return null;
+				case '>':
+					return EmitTagToken ();
+				case '"': case '\'': case '<':
+					// parse error
+					goto default;
+				default:
+					TokenizerState = HtmlTokenizerState.AttributeName;
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.37 Before attribute value state
+		HtmlToken ReadBeforeAttributeValue ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					tag = null;
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '"': case '\'':
+					TokenizerState = HtmlTokenizerState.AttributeValueQuoted;
+					quote = c;
+					return null;
+				case '&':
+					TokenizerState = HtmlTokenizerState.CharacterReferenceInAttributeValue;
+					return null;
+				case '/':
+					TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+					return null;
+				case '>':
+					return EmitTagToken ();
+				case '<': case '=': case '`':
+					// parse error
+					goto default;
+				default:
+					TokenizerState = HtmlTokenizerState.AttributeValueUnquoted;
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.38 Attribute value (double-quoted) state
+		HtmlToken ReadAttributeValueQuoted ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '&':
+					TokenizerState = HtmlTokenizerState.CharacterReferenceInAttributeValue;
+					return null;
+				default:
+					if (c == quote) {
+						TokenizerState = HtmlTokenizerState.AfterAttributeValueQuoted;
+						quote = '\0';
+						break;
+					}
+
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.AttributeValueQuoted);
+
+			attribute.Value = name.ToString ();
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.40 Attribute value (unquoted) state
+		HtmlToken ReadAttributeValueUnquoted ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					name.Next();
+
+					return EmitDataToken (false, true);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+					break;
+				case '&':
+					TokenizerState = HtmlTokenizerState.CharacterReferenceInAttributeValue;
+					return null;
+				case '>':
+					attribute.Value = name.ToString ();
+					name.Next();
+
+					return EmitTagToken ();
+				case '\'': case '<': case '=': case '`':
+					// parse error
+					goto default;
+				default:
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.AttributeValueUnquoted);
+
+			attribute.Value = name.ToString ();
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.41 Character reference in attribute value state
+		HtmlToken ReadCharacterReferenceInAttributeValue ()
+		{
+			char additionalAllowedCharacter = quote == '\0' ? '>' : quote;
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				name.Next();
+
+				return EmitDataToken (false, true);
+			}
+
+			c = (char) nc;
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ': case '<': case '&':
+				// no character is consumed, emit '&'
+				name.Append ('&');
+				break;
+			default:
+				if (c == additionalAllowedCharacter) {
+					// this is not a character reference, nothing is consumed
+					name.Append ('&');
+					break;
+				}
+
+				entity.Push ('&');
+
+				while (entity.Push (c)) {
+					Read ();
+
+					if (c == ';')
+						break;
+
+					if ((nc = Peek ()) == -1) {
+						TokenizerState = HtmlTokenizerState.EndOfFile;
+						data.MoveBack ();
+						data.Append (entity.GetPushedInput ());
+						entity.Reset ();
+
+						return EmitDataToken (false, true);
+					}
+
+					c = (char) nc;
+				}
+
+				var pushed = entity.GetPushedInput ();
+				string value;
+
+				if (c == '=' || IsAlphaNumeric (c))
+					value = pushed;
+				else
+					value = entity.GetValue ();
+
+				data.MoveBack ();
+				data.Append (pushed);
+				name.Append (value);
+				entity.Reset ();
+				break;
+			}
+
+			if (quote == '\0')
+				TokenizerState = HtmlTokenizerState.AttributeValueUnquoted;
+			else
+				TokenizerState = HtmlTokenizerState.AttributeValueQuoted;
+
+			return null;
+		}
+
+		// 8.2.4.42 After attribute value (quoted) state
+		HtmlToken ReadAfterAttributeValueQuoted ()
+		{
+			HtmlToken token = null;
+			int nc = Peek ();
+			bool consume;
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitDataToken (false, true);
+			}
+
+			c = (char) nc;
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ':
+				TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+				data.Append (c);
+				consume = true;
+				break;
+			case '/':
+				TokenizerState = HtmlTokenizerState.SelfClosingStartTag;
+				data.Append (c);
+				consume = true;
+				break;
+			case '>':
+				token = EmitTagToken ();
+				consume = true;
+				break;
+			default:
+				TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+				consume = false;
+				break;
+			}
+
+			if (consume)
+				Read ();
+
+			return token;
+		}
+
+		// 8.2.4.43 Self-closing start tag state
+		HtmlToken ReadSelfClosingStartTag ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitDataToken (false, true);
+			}
+
+			c = (char) nc;
+
+			if (c == '>') {
+				tag.IsEmptyElement = true;
+
+				return EmitTagToken ();
+			}
+
+			// parse error
+			TokenizerState = HtmlTokenizerState.BeforeAttributeName;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append (c);
+
+			return null;
+		}
+
+		// 8.2.4.44 Bogus comment state
+		HtmlToken ReadBogusComment ()
+		{
+			int nc;
+			char c;
+
+			do {
+				if ((nc = Read ()) == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					break;
+				}
+
+				if ((c = (char) nc) == '>')
+					break;
+
+				data.Append (c == '\0' ? '\uFFFD' : c);
+			} while (true);
+
+			TokenizerState = HtmlTokenizerState.Data;
+
+			return EmitCommentToken (data, true);
+		}
+
+		// 8.2.4.45 Markup declaration open state
+		HtmlToken ReadMarkupDeclarationOpen ()
+		{
+			int count = 0, nc;
+			char c = '\0';
+
+			while (count < 2) {
+				if ((nc = Peek ()) == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitDataToken (false, true);
+				}
+
+				if ((c = (char) nc) != '-')
+					break;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+				Read ();
+				count++;
+			}
+
+			if (count == 2) {
+				// "<!--"
+				TokenizerState = HtmlTokenizerState.CommentStart;
+				name.Next();
+				return null;
+			}
+
+			if (count == 0) {
+				// Check for "<!DOCTYPE " or "<![CDATA["
+				if (c == 'D' || c == 'd') {
+					// Note: we save the data in case we hit a parse error and have to emit a data token
+					data.Append (c);
+					name.Append (c);
+					count = 1;
+					Read ();
+
+					while (count < 7) {
+						if ((nc = Read ()) == -1) {
+							TokenizerState = HtmlTokenizerState.EndOfFile;
+							return EmitDataToken (false, true);
+						}
+
+						c = (char) nc;
+
+						// Note: we save the data in case we hit a parse error and have to emit a data token
+						data.Append (c);
+						name.Append (c);
+
+						if (ToLower (c) != DocType[count])
+							break;
+
+						count++;
+					}
+
+					if (count == 7) {
+						doctype = CreateDocTypeToken (name.ToString ());
+						TokenizerState = HtmlTokenizerState.DocType;
+						name.Next();
+						return null;
+					}
+
+					name.Next();
+				} else if (c == '[') {
+					// Note: we save the data in case we hit a parse error and have to emit a data token
+					data.Append (c);
+					count = 1;
+					Read ();
+
+					while (count < 7) {
+						if ((nc = Read ()) == -1) {
+							TokenizerState = HtmlTokenizerState.EndOfFile;
+							return EmitDataToken (false, true);
+						}
+
+						c = (char) nc;
+
+						// Note: we save the data in case we hit a parse error and have to emit a data token
+						data.Append (c);
+
+						if (c != CData[count])
+							break;
+
+						count++;
+					}
+
+					if (count == 7) {
+						TokenizerState = HtmlTokenizerState.CDataSection;
+						data.Next();
+						return null;
+					}
+				}
+			}
+
+			// parse error
+			TokenizerState = HtmlTokenizerState.BogusComment;
+
+			// trim the leading "<!"
+			for (int i = 0; i < data.Length - 2; i++)
+				data[i] = data[i + 2];
+			data.MoveBack ();
+			data.MoveBack ();
+			bang = true;
+
+			return null;
+		}
+
+		// 8.2.4.46 Comment start state
+		HtmlToken ReadCommentStart ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.Data;
+
+				return EmitCommentToken (string.Empty);
+			}
+
+			c = (char) nc;
+
+			data.Append (c);
+
+			switch (c) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.CommentStartDash;
+				break;
+			case '>': // parse error
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitCommentToken (string.Empty);
+			default:
+				TokenizerState = HtmlTokenizerState.Comment;
+				name.Append (c == '\0' ? '\uFFFD' : c);
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.47 Comment start dash state
+		HtmlToken ReadCommentStartDash ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitCommentToken (name);
+			}
+
+			c = (char) nc;
+
+			data.Append (c);
+
+			switch (c) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.CommentEnd;
+				break;
+			case '>': // parse error
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitCommentToken (name);
+			default:
+				TokenizerState = HtmlTokenizerState.Comment;
+				name.Append ('-');
+				name.Append (c == '\0' ? '\uFFFD' : c);
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.48 Comment state
+		HtmlToken ReadComment ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitCommentToken (name);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '-':
+					TokenizerState = HtmlTokenizerState.CommentEndDash;
+					return null;
+				default:
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					break;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.49 Comment end dash state
+		HtmlToken ReadCommentEndDash ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitCommentToken (name);
+			}
+
+			c = (char) nc;
+
+			data.Append (c);
+
+			switch (c) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.CommentEnd;
+				break;
+			default:
+				TokenizerState = HtmlTokenizerState.Comment;
+				name.Append ('-');
+				name.Append (c == '\0' ? '\uFFFD' : c);
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.50 Comment end state
+		HtmlToken ReadCommentEnd ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					return EmitCommentToken (name);
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					return EmitCommentToken (name);
+				case '!': // parse error
+					TokenizerState = HtmlTokenizerState.CommentEndBang;
+					return null;
+				case '-':
+					name.Append ('-');
+					break;
+				default:
+					TokenizerState = HtmlTokenizerState.Comment;
+					name.Append ("--");
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.51 Comment end bang state
+		HtmlToken ReadCommentEndBang ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				return EmitCommentToken (name);
+			}
+
+			c = (char) nc;
+
+			data.Append (c);
+
+			switch (c) {
+			case '-':
+				TokenizerState = HtmlTokenizerState.CommentEndDash;
+				name.Append ("--!");
+				break;
+			case '>':
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitCommentToken (name);
+			default: // parse error
+				TokenizerState = HtmlTokenizerState.Comment;
+				name.Append ("--!");
+				name.Append (c == '\0' ? '\uFFFD' : c);
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.52 DOCTYPE state
+		HtmlToken ReadDocType ()
+		{
+			int nc = Peek ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				doctype.ForceQuirksMode = true;
+				name.Next();
+
+				return EmitDocType ();
+			}
+
+			TokenizerState = HtmlTokenizerState.BeforeDocTypeName;
+			c = (char) nc;
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ':
+				data.Append (c);
+				Read ();
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.53 Before DOCTYPE name state
+		HtmlToken ReadBeforeDocTypeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				default:
+					TokenizerState = HtmlTokenizerState.DocTypeName;
+					name.Append (c == '\0' ? '\uFFFD' : c);
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.54 DOCTYPE name state
+		HtmlToken ReadDocTypeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.Name = name.ToString ();
+					doctype.ForceQuirksMode = true;
+					name.Next();
+
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					TokenizerState = HtmlTokenizerState.AfterDocTypeName;
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.Name = name.ToString ();
+					name.Next();
+
+					return EmitDocType ();
+				case '\0':
+					name.Append ('\uFFFD');
+					break;
+				default:
+					name.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.DocTypeName);
+
+			doctype.Name = name.ToString ();
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.55 After DOCTYPE name state
+		HtmlToken ReadAfterDocTypeName ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					return EmitDocType ();
+				default:
+					name.Append (c);
+					if (name.Length < 6)
+						break;
+
+					if (NameIs ("public")) {
+						TokenizerState = HtmlTokenizerState.AfterDocTypePublicKeyword;
+						doctype.PublicKeyword = name.ToString ();
+					} else if (NameIs ("system")) {
+						TokenizerState = HtmlTokenizerState.AfterDocTypeSystemKeyword;
+						doctype.SystemKeyword = name.ToString ();
+					} else {
+						TokenizerState = HtmlTokenizerState.BogusDocType;
+					}
+
+					name.Next();
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.56 After DOCTYPE public keyword state
+		HtmlToken ReadAfterDocTypePublicKeyword ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				doctype.ForceQuirksMode = true;
+				return EmitDocType ();
+			}
+
+			c = (char) nc;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append (c);
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ':
+				TokenizerState = HtmlTokenizerState.BeforeDocTypePublicIdentifier;
+				break;
+			case '"': case '\'': // parse error
+				TokenizerState = HtmlTokenizerState.DocTypePublicIdentifierQuoted;
+				doctype.PublicIdentifier = string.Empty;
+				quote = c;
+				break;
+			case '>': // parse error
+				TokenizerState = HtmlTokenizerState.Data;
+				doctype.ForceQuirksMode = true;
+				return EmitDocType ();
+			default: // parse error
+				TokenizerState = HtmlTokenizerState.BogusDocType;
+				doctype.ForceQuirksMode = true;
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.57 Before DOCTYPE public identifier state
+		HtmlToken ReadBeforeDocTypePublicIdentifier ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '"': case '\'':
+					TokenizerState = HtmlTokenizerState.DocTypePublicIdentifierQuoted;
+					doctype.PublicIdentifier = string.Empty;
+					quote = c;
+					return null;
+				case '>': // parse error
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				default: // parse error
+					TokenizerState = HtmlTokenizerState.BogusDocType;
+					doctype.ForceQuirksMode = true;
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.58 DOCTYPE public identifier (double-quoted) state
+		HtmlToken ReadDocTypePublicIdentifierQuoted ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.PublicIdentifier = name.ToString ();
+					doctype.ForceQuirksMode = true;
+					name.Next();
+
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\0': // parse error
+					name.Append ('\uFFFD');
+					break;
+				case '>': // parse error
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.PublicIdentifier = name.ToString ();
+					doctype.ForceQuirksMode = true;
+					name.Next();
+
+					return EmitDocType ();
+				default:
+					if (c == quote) {
+						TokenizerState = HtmlTokenizerState.AfterDocTypePublicIdentifier;
+						quote = '\0';
+						break;
+					}
+
+					name.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.DocTypePublicIdentifierQuoted);
+
+			doctype.PublicIdentifier = name.ToString ();
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.60 After DOCTYPE public identifier state
+		HtmlToken ReadAfterDocTypePublicIdentifier ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				doctype.ForceQuirksMode = true;
+				return EmitDocType ();
+			}
+
+			c = (char) nc;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append (c);
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ':
+				TokenizerState = HtmlTokenizerState.BetweenDocTypePublicAndSystemIdentifiers;
+				break;
+			case '>':
+				TokenizerState = HtmlTokenizerState.Data;
+				return EmitDocType ();
+			case '"': case '\'': // parse error
+				TokenizerState = HtmlTokenizerState.DocTypeSystemIdentifierQuoted;
+				doctype.SystemIdentifier = string.Empty;
+				quote = c;
+				break;
+			default: // parse error
+				TokenizerState = HtmlTokenizerState.BogusDocType;
+				doctype.ForceQuirksMode = true;
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.61 Between DOCTYPE public and system identifiers state
+		HtmlToken ReadBetweenDocTypePublicAndSystemIdentifiers ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					return EmitDocType ();
+				case '"': case '\'':
+					TokenizerState = HtmlTokenizerState.DocTypeSystemIdentifierQuoted;
+					doctype.SystemIdentifier = string.Empty;
+					quote = c;
+					return null;
+				default: // parse error
+					TokenizerState = HtmlTokenizerState.BogusDocType;
+					doctype.ForceQuirksMode = true;
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.62 After DOCTYPE system keyword state
+		HtmlToken ReadAfterDocTypeSystemKeyword ()
+		{
+			int nc = Read ();
+			char c;
+
+			if (nc == -1) {
+				TokenizerState = HtmlTokenizerState.EndOfFile;
+				doctype.ForceQuirksMode = true;
+				return EmitDocType ();
+			}
+
+			c = (char) nc;
+
+			// Note: we save the data in case we hit a parse error and have to emit a data token
+			data.Append (c);
+
+			switch (c) {
+			case '\t': case '\r': case '\n': case '\f': case ' ':
+				TokenizerState = HtmlTokenizerState.BeforeDocTypeSystemIdentifier;
+				break;
+			case '"': case '\'': // parse error
+				TokenizerState = HtmlTokenizerState.DocTypeSystemIdentifierQuoted;
+				doctype.SystemIdentifier = string.Empty;
+				quote = c;
+				break;
+			case '>': // parse error
+				TokenizerState = HtmlTokenizerState.Data;
+				doctype.ForceQuirksMode = true;
+				return EmitDocType ();
+			default: // parse error
+				TokenizerState = HtmlTokenizerState.BogusDocType;
+				doctype.ForceQuirksMode = true;
+				break;
+			}
+
+			return null;
+		}
+
+		// 8.2.4.63 Before DOCTYPE system identifier state
+		HtmlToken ReadBeforeDocTypeSystemIdentifier ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case '\r': case '\n': case '\f': case ' ':
+					break;
+				case '"': case '\'':
+					TokenizerState = HtmlTokenizerState.DocTypeSystemIdentifierQuoted;
+					doctype.SystemIdentifier = string.Empty;
+					quote = c;
+					return null;
+				case '>': // parse error
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				default: // parse error
+					TokenizerState = HtmlTokenizerState.BogusDocType;
+					doctype.ForceQuirksMode = true;
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.64 DOCTYPE system identifier (double-quoted) state
+		HtmlToken ReadDocTypeSystemIdentifierQuoted ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.SystemIdentifier = name.ToString ();
+					doctype.ForceQuirksMode = true;
+					name.Next();
+
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\0': // parse error
+					name.Append ('\uFFFD');
+					break;
+				case '>': // parse error
+					TokenizerState = HtmlTokenizerState.Data;
+					doctype.SystemIdentifier = name.ToString ();
+					doctype.ForceQuirksMode = true;
+					name.Next();
+
+					return EmitDocType ();
+				default:
+					if (c == quote) {
+						TokenizerState = HtmlTokenizerState.AfterDocTypeSystemIdentifier;
+						quote = '\0';
+						break;
+					}
+
+					name.Append (c);
+					break;
+				}
+			} while (TokenizerState == HtmlTokenizerState.DocTypeSystemIdentifierQuoted);
+
+			doctype.SystemIdentifier = name.ToString ();
+			name.Next();
+
+			return null;
+		}
+
+		// 8.2.4.66 After DOCTYPE system identifier state
+		HtmlToken ReadAfterDocTypeSystemIdentifier ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				switch (c) {
+				case '\t': case'\r': case '\n': case '\f': case ' ':
+					break;
+				case '>':
+					TokenizerState = HtmlTokenizerState.Data;
+					return EmitDocType ();
+				default: // parse error
+					TokenizerState = HtmlTokenizerState.BogusDocType;
+					return null;
+				}
+			} while (true);
+		}
+
+		// 8.2.4.67 Bogus DOCTYPE state
+		HtmlToken ReadBogusDocType ()
+		{
+			do {
+				int nc = Read ();
+				char c;
+
+				if (nc == -1) {
+					TokenizerState = HtmlTokenizerState.EndOfFile;
+					doctype.ForceQuirksMode = true;
+					return EmitDocType ();
+				}
+
+				c = (char) nc;
+
+				// Note: we save the data in case we hit a parse error and have to emit a data token
+				data.Append (c);
+
+				if (c == '>') {
+					TokenizerState = HtmlTokenizerState.Data;
+					return EmitDocType ();
+				}
+			} while (true);
+		}
+
+		// 8.2.4.68 CDATA section state
+		HtmlToken ReadCDataSection ()
+		{
+			int nc = Read ();
+
+			while (nc != -1) {
+				char c = (char) nc;
+
+				if (cdataIndex >= 3) {
+					data.Append (cdata[0]);
+					cdata[0] = cdata[1];
+					cdata[1] = cdata[2];
+					cdata[2] = c;
+
+					if (cdata[0] == ']' && cdata[1] == ']' && cdata[2] == '>') {
+						TokenizerState = HtmlTokenizerState.Data;
+						cdataIndex = 0;
+
+						return EmitCDataToken ();
+					}
+				} else {
+					cdata[cdataIndex++] = c;
+				}
+
+				nc = Read ();
+			}
+
+			TokenizerState = HtmlTokenizerState.EndOfFile;
+
+			for (int i = 0; i < cdataIndex; i++)
+				data.Append (cdata[i]);
+
+			cdataIndex = 0;
+
+			return EmitCDataToken ();
+		}
+
+		/// <summary>
+		/// Read the next token.
+		/// </summary>
+		/// <remarks>
+		/// Reads the next token.
+		/// </remarks>
+		/// <returns><c>true</c> if the next token was read; otherwise, <c>false</c>.</returns>
+		/// <param name="token">The token that was read.</param>
+		public bool ReadNextToken (out HtmlToken token)
+		{
+			do {
+				switch (TokenizerState) {
+				case HtmlTokenizerState.Data:
+					token = ReadData ();
+					break;
+				case HtmlTokenizerState.CharacterReferenceInData:
+					token = ReadCharacterReferenceInData ();
+					break;
+				case HtmlTokenizerState.RcData:
+					token = ReadRcData ();
+					break;
+				case HtmlTokenizerState.CharacterReferenceInRcData:
+					token = ReadCharacterReferenceInRcData ();
+					break;
+				case HtmlTokenizerState.RawText:
+					token = ReadRawText ();
+					break;
+				case HtmlTokenizerState.ScriptData:
+					token = ReadScriptData ();
+					break;
+				case HtmlTokenizerState.PlainText:
+					token = ReadPlainText ();
+					break;
+				case HtmlTokenizerState.TagOpen:
+					token = ReadTagOpen ();
+					break;
+				case HtmlTokenizerState.EndTagOpen:
+					token = ReadEndTagOpen ();
+					break;
+				case HtmlTokenizerState.TagName:
+					token = ReadTagName ();
+					break;
+				case HtmlTokenizerState.RcDataLessThan:
+					token = ReadRcDataLessThan ();
+					break;
+				case HtmlTokenizerState.RcDataEndTagOpen:
+					token = ReadRcDataEndTagOpen ();
+					break;
+				case HtmlTokenizerState.RcDataEndTagName:
+					token = ReadRcDataEndTagName ();
+					break;
+				case HtmlTokenizerState.RawTextLessThan:
+					token = ReadRawTextLessThan ();
+					break;
+				case HtmlTokenizerState.RawTextEndTagOpen:
+					token = ReadRawTextEndTagOpen ();
+					break;
+				case HtmlTokenizerState.RawTextEndTagName:
+					token = ReadRawTextEndTagName ();
+					break;
+				case HtmlTokenizerState.ScriptDataLessThan:
+					token = ReadScriptDataLessThan ();
+					break;
+				case HtmlTokenizerState.ScriptDataEndTagOpen:
+					token = ReadScriptDataEndTagOpen ();
+					break;
+				case HtmlTokenizerState.ScriptDataEndTagName:
+					token = ReadScriptDataEndTagName ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapeStart:
+					token = ReadScriptDataEscapeStart ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapeStartDash:
+					token = ReadScriptDataEscapeStartDash ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscaped:
+					token = ReadScriptDataEscaped ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapedDash:
+					token = ReadScriptDataEscapedDash ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapedDashDash:
+					token = ReadScriptDataEscapedDashDash ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapedLessThan:
+					token = ReadScriptDataEscapedLessThan ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapedEndTagOpen:
+					token = ReadScriptDataEscapedEndTagOpen ();
+					break;
+				case HtmlTokenizerState.ScriptDataEscapedEndTagName:
+					token = ReadScriptDataEscapedEndTagName ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscapeStart:
+					token = ReadScriptDataDoubleEscapeStart ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscaped:
+					token = ReadScriptDataDoubleEscaped ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscapedDash:
+					token = ReadScriptDataDoubleEscapedDash ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscapedDashDash:
+					token = ReadScriptDataDoubleEscapedDashDash ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscapedLessThan:
+					token = ReadScriptDataDoubleEscapedLessThan ();
+					break;
+				case HtmlTokenizerState.ScriptDataDoubleEscapeEnd:
+					token = ReadScriptDataDoubleEscapeEnd ();
+					break;
+				case HtmlTokenizerState.BeforeAttributeName:
+					token = ReadBeforeAttributeName ();
+					break;
+				case HtmlTokenizerState.AttributeName:
+					token = ReadAttributeName ();
+					break;
+				case HtmlTokenizerState.AfterAttributeName:
+					token = ReadAfterAttributeName ();
+					break;
+				case HtmlTokenizerState.BeforeAttributeValue:
+					token = ReadBeforeAttributeValue ();
+					break;
+				case HtmlTokenizerState.AttributeValueQuoted:
+					token = ReadAttributeValueQuoted ();
+					break;
+				case HtmlTokenizerState.AttributeValueUnquoted:
+					token = ReadAttributeValueUnquoted ();
+					break;
+				case HtmlTokenizerState.CharacterReferenceInAttributeValue:
+					token = ReadCharacterReferenceInAttributeValue ();
+					break;
+				case HtmlTokenizerState.AfterAttributeValueQuoted:
+					token = ReadAfterAttributeValueQuoted ();
+					break;
+				case HtmlTokenizerState.SelfClosingStartTag:
+					token = ReadSelfClosingStartTag ();
+					break;
+				case HtmlTokenizerState.BogusComment:
+					token = ReadBogusComment ();
+					break;
+				case HtmlTokenizerState.MarkupDeclarationOpen:
+					token = ReadMarkupDeclarationOpen ();
+					break;
+				case HtmlTokenizerState.CommentStart:
+					token = ReadCommentStart ();
+					break;
+				case HtmlTokenizerState.CommentStartDash:
+					token = ReadCommentStartDash ();
+					break;
+				case HtmlTokenizerState.Comment:
+					token = ReadComment ();
+					break;
+				case HtmlTokenizerState.CommentEndDash:
+					token = ReadCommentEndDash ();
+					break;
+				case HtmlTokenizerState.CommentEnd:
+					token = ReadCommentEnd ();
+					break;
+				case HtmlTokenizerState.CommentEndBang:
+					token = ReadCommentEndBang ();
+					break;
+				case HtmlTokenizerState.DocType:
+					token = ReadDocType ();
+					break;
+				case HtmlTokenizerState.BeforeDocTypeName:
+					token = ReadBeforeDocTypeName ();
+					break;
+				case HtmlTokenizerState.DocTypeName:
+					token = ReadDocTypeName ();
+					break;
+				case HtmlTokenizerState.AfterDocTypeName:
+					token = ReadAfterDocTypeName ();
+					break;
+				case HtmlTokenizerState.AfterDocTypePublicKeyword:
+					token = ReadAfterDocTypePublicKeyword ();
+					break;
+				case HtmlTokenizerState.BeforeDocTypePublicIdentifier:
+					token = ReadBeforeDocTypePublicIdentifier ();
+					break;
+				case HtmlTokenizerState.DocTypePublicIdentifierQuoted:
+					token = ReadDocTypePublicIdentifierQuoted ();
+					break;
+				case HtmlTokenizerState.AfterDocTypePublicIdentifier:
+					token = ReadAfterDocTypePublicIdentifier ();
+					break;
+				case HtmlTokenizerState.BetweenDocTypePublicAndSystemIdentifiers:
+					token = ReadBetweenDocTypePublicAndSystemIdentifiers ();
+					break;
+				case HtmlTokenizerState.AfterDocTypeSystemKeyword:
+					token = ReadAfterDocTypeSystemKeyword ();
+					break;
+				case HtmlTokenizerState.BeforeDocTypeSystemIdentifier:
+					token = ReadBeforeDocTypeSystemIdentifier ();
+					break;
+				case HtmlTokenizerState.DocTypeSystemIdentifierQuoted:
+					token = ReadDocTypeSystemIdentifierQuoted ();
+					break;
+				case HtmlTokenizerState.AfterDocTypeSystemIdentifier:
+					token = ReadAfterDocTypeSystemIdentifier ();
+					break;
+				case HtmlTokenizerState.BogusDocType:
+					token = ReadBogusDocType ();
+					break;
+				case HtmlTokenizerState.CDataSection:
+					token = ReadCDataSection ();
+					break;
+				case HtmlTokenizerState.EndOfFile:
+				default:
+					token = null;
+					return false;
+				}
+			} while (token is null);
+
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
This is just WIP to demonstrate something. But the results are very promising.

![image](https://user-images.githubusercontent.com/1236435/228638528-b42ae12c-dcc7-452e-a8dd-845675e9930f.png)

The charbuffer creates a lot of allocations, because the string needs to be created. My idea was to use a large buffer of 4 MB (size can be changed ofc) and put all strings into this buffer. The we use the default objectpool to reuse the buffer.

I am not sure yet, if it works. But if it does, the performance gain would be usage (see screenshot).

I have created V2 versions of the parser to make it easier to compare both versions.
